### PR TITLE
GH #5 deduction: add current_function_at()

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ This manual detection will be obsolete when `clang_getCanonicalType()` API will 
 
 Get type at specific location with auto-deduction described above.
 
+### `libclang#deduction#current_function_at({filename}, {line}, {col} [, {compiler args}])`
+
+Get the name of the qualified name of the current function at specific location.
+
 ## Installation
 
 ### LLVM Installation

--- a/autoload/libclang/deduction.vim
+++ b/autoload/libclang/deduction.vim
@@ -10,4 +10,7 @@ endfunction
 function! libclang#deduction#type_at(filename, line, col, ...)
     return libclang#call_at('vim_clang_get_type_with_deduction_at', a:filename, a:line, a:col, a:000)
 endfunction
+function! libclang#deduction#current_function_at(filename, line, col, ...)
+    return libclang#call_at('vim_clang_get_current_function_at', a:filename, a:line, a:col, a:000)
+endfunction
 

--- a/lib/libclang-vim/clang_vim.cpp
+++ b/lib/libclang-vim/clang_vim.cpp
@@ -607,5 +607,19 @@ char const* vim_clang_get_type_with_deduction_at(char const* location_string)
     return ret;
 }
 
+char const* vim_clang_get_current_function_at(char const* location_string)
+{
+    // Close stderr.
+    int old_stderr = dup(2);
+    close(2);
+
+    const char* ret = libclang_vim::get_current_function_at(libclang_vim::parse_args_with_location(location_string));
+
+    // Restore stderr.
+    dup(old_stderr);
+    close(old_stderr);
+    return ret;
+}
+
 } // extern "C"
 


### PR DESCRIPTION
Example usage:

    let compiler_args = '-std=c++1y'
    let info = libclang#deduction#current_function_at(expand('%:p'), line('.'), col('.'), compiler_args)
    echo info.name

I find this especially useful when the function name is defined by some macro.